### PR TITLE
Added missing Simplified Chinese Translation

### DIFF
--- a/Languages/ChineseSimplified/Keyed/Keyed.xml
+++ b/Languages/ChineseSimplified/Keyed/Keyed.xml
@@ -22,4 +22,11 @@
   <Fluffy.Pharmacist.Severity.LifeThreathening.Tip>致命伤害，失血或心脏病。</Fluffy.Pharmacist.Severity.LifeThreathening.Tip>
   <Fluffy.Pharmacist.Severity.Operation.Tip>所有手术，器官移植和肢体替换。</Fluffy.Pharmacist.Severity.Operation.Tip>
 
+  <Fluffy.Pharmacist.DiseaseMargin>疾病免疫性安全边距: {0}</Fluffy.Pharmacist.DiseaseMargin>
+	<Fluffy.Pharmacist.DiseaseMargin.Tip>治疗疾病时严重性到免疫性的安全边距。 \n\n如果疾病严重性加上这个边距超过了疾病免疫性（并且严重性超过了安全临界值），医生将视为致命伤害来治疗。\n\n例：如果一次伤口感染严重性达到了80%，患者的免疫性达到了85%，安全疾病边距为10%，那么这次伤口感染将使用你设定的致命伤害级别的医疗手段来治疗。如果边距只有5%，那么这次伤口感染只会用默认的重伤级别的医疗手段来治疗。</Fluffy.Pharmacist.DiseaseMargin.Tip>
+	<Fluffy.Pharmacist.DiseaseThreshold>疾病严重性安全临界值: {0}</Fluffy.Pharmacist.DiseaseThreshold>
+	<Fluffy.Pharmacist.DiseaseThreshold.Tip>超过此严重性的疾病会被视为致命的。 \n\n如果疾病严重性超过了这个临界值（并且免疫性低于严重性加上免疫性安全边距），医生将视为致命伤害来治疗。</Fluffy.Pharmacist.DiseaseThreshold.Tip>
+	<Fluffy.Pharmacist.MinorWoundsThreshold>轻伤数量临界值: {0}</Fluffy.Pharmacist.MinorWoundsThreshold>
+	<Fluffy.Pharmacist.MinorWoundsThreshold.Tip>如果轻伤的数量达到了这个临界值，那么无论流血多少，医生都会视为重伤来治疗。 \n\n主要用来防止“凌迟至死”，即过多的轻伤有可能导致多项感染，最终不治身亡。</Fluffy.Pharmacist.MinorWoundsThreshold.Tip>
+
 </LanguageData>

--- a/Languages/English/Keyed/Keyed.xml
+++ b/Languages/English/Keyed/Keyed.xml
@@ -24,7 +24,7 @@
 
 	<Fluffy.Pharmacist.DiseaseMargin>Disease immunity margin: {0}</Fluffy.Pharmacist.DiseaseMargin>
 	<Fluffy.Pharmacist.DiseaseMargin.Tip>Security margin used when treating diseases. \n\nIf immunity is lower than disease progress plus this margin (and severity is higher than the minimum threshold), the disease is treated as a life-threathening injury.\n\nFor example, if a disease has progressed 75%, immunity is at 80%, and the margin is 10%, the disease will be classed as life-threatening. If the threshold was 5%, the disease would be classed as a major injury instead.</Fluffy.Pharmacist.DiseaseMargin.Tip>
-	<Fluffy.Pharmacist.DiseaseThreshold>Disease minimum severity theshold: {0}</Fluffy.Pharmacist.DiseaseThreshold>
+	<Fluffy.Pharmacist.DiseaseThreshold>Disease minimum severity threshold: {0}</Fluffy.Pharmacist.DiseaseThreshold>
 	<Fluffy.Pharmacist.DiseaseThreshold.Tip>Minimum severity before a disease can be classed as potentially lethal. \n\nIf severity is higher than this threshold (and immunity is lower than the severity plus security margin), the disease is treated as a life-threathening injury.</Fluffy.Pharmacist.DiseaseThreshold.Tip>
 	<Fluffy.Pharmacist.MinorWoundsThreshold>Minor cuts threshold: {0}</Fluffy.Pharmacist.MinorWoundsThreshold>
 	<Fluffy.Pharmacist.MinorWoundsThreshold.Tip>If the number of minor cuts is greater than this threshold, they are treated as a major injury regardless of bleed rate. \n\nUseful to prevent 'death by a thousand cuts', where a large number of small cuts can cause multiple infections - and ultimately, death.</Fluffy.Pharmacist.MinorWoundsThreshold.Tip>


### PR DESCRIPTION
Add Chinese translation to disease immunity margin, disease severity threshold and minor cuts threshold, which is currently missing. Also corrected a small typo (theshold -> threshold) in the English description. 