### PR TITLE
Fix: Sequence contains no elements Exception

### DIFF
--- a/Source/HarmonyPatches/HealthAIUtility_FindBestMedicine.cs
+++ b/Source/HarmonyPatches/HealthAIUtility_FindBestMedicine.cs
@@ -43,9 +43,11 @@ namespace Pharmacist {
             //
             // thanks to KennethSammael for adding this check in the unofficial 1.3 update,
             // this code is adapted from his changes.
-            __result = healer.inventory.innerContainer
-                .Where(allowedPredicate)
-                .MaxBy(potencyGetter);
+            var allowedMedicine = healer.inventory.innerContainer.Where(allowedPredicate);
+            if (allowedMedicine.Any()) {
+                __result = allowedMedicine.MaxBy(potencyGetter);
+
+            }
             if (__result is not null || onlyUseInventory) {
                 return false;
             }


### PR DESCRIPTION
Check whether the healer's medical inventory is empty before sort.

Since I'm not familiar with RW's modding so I didn't include the assembly file.